### PR TITLE
Estilos de bloques encolados.

### DIFF
--- a/blocks/wordpycat-block/block.json
+++ b/blocks/wordpycat-block/block.json
@@ -4,7 +4,8 @@
     "description": "Descripción del bloque de ejemplo.",
     "category": "wordpycat",
     "icon": "embed-post",
-    "style": ["file:./estilos.css"],
+    "style": ["worpycat-block-style"],
+    "viewScript": ["worpypcat-block-js"],
     "keywords": ["featured", "blog", "posts", "selection"],
     "apiVersion": 2,
     "acf": {

--- a/blocks/wordpycat-block/readme.md
+++ b/blocks/wordpycat-block/readme.md
@@ -3,5 +3,5 @@ Este es un bloque de ejemplo. Este bloque se registrará en la función dentro d
 Cada bloque contiene:
 - Archivo block.json para la información de [registro del bloque](https://www.advancedcustomfields.com/resources/create-your-first-acf-block/#registering-blocks-with-blockjson).
 - Template del bloque
-- Hoja de estilos del bloque (opcional)
+- Hoja de estilos del bloque (opcional). En el caso de que se meta una hoja de estilos, además de meterlo en el block.json, habrá que registrarlo en **includes/block.php**
 - Script (opcional). En el caso de que se meta un script, además de meterlo en el block.json, habrá que registrarlo en **includes/block.php**

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -28,6 +28,20 @@ function registrar_bloques() {
 
 add_action( 'acf/init', 'registrar_bloques' );
 
+/**
+ * Registrar scripts de los bloques
+ */
+
+function registrar_estilo_bloques() {
+    $version = '1.0.0';
+
+    // Añadir aquí los scripts de todos los bloques
+    wp_register_style( 'wordpycat-block-style', get_template_directory_uri() . 'blocks/wordpycat-block/estilos.css', array(), $version );
+
+}
+
+add_action( 'acf/init', 'registrar_estilo_bloques' );
+
 
 
 /**
@@ -38,7 +52,7 @@ add_action( 'acf/init', 'registrar_bloques' );
     $version = '1.0.0';
 
     // Añadir aquí los scripts de todos los bloques
-    wp_register_script( 'wordpycat-block', get_template_directory_uri() . 'blocks/wordpycat-block/app.js', array( 'acf' ), $version, true );
+    wp_register_script( 'wordpycat-block-js', get_template_directory_uri() . 'blocks/wordpycat-block/app.js', array( 'acf' ), $version, true );
 
 }
 


### PR DESCRIPTION
Cambiar bloque de ejemplo para que la hoja de estilos se encole (en lugar de escribirse en el head)